### PR TITLE
Add CI building of GPL static builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -165,7 +165,7 @@ jobs:
       fail-fast: false
       matrix:
         target: [win64] # Choose targets here if you want specific ones
-        variant: [lgpl-shared, lgpl-shared 7.0] # Only build this variant
+        variant: [lgpl-shared, lgpl-shared 7.0, gpl, gpl 7.0] # Only build this variant
     steps:
       - name: Free Disk-Space
         run: df -h && sudo apt-get clean && docker system prune -a -f && sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc && df -h
@@ -230,7 +230,7 @@ jobs:
       fail-fast: false
       matrix:
         target: [win64] # Choose targets here if you want specific ones
-        variant: [lgpl-shared, lgpl-shared 7.0] # Only build this variant
+        variant: [lgpl-shared, lgpl-shared 7.0, gpl, gpl 7.0] # Only build this variant
     steps:
       - name: Free Disk-Space
         run: df -h && sudo apt-get clean && docker system prune -a -f && sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc && df -h


### PR DESCRIPTION
These can be used for now as the static EXEs we ship with the recorder.