### PR TITLE
Enable building for WinARM64

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -109,7 +109,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        target: [win64] # Choose targets here if you want specific ones
+        target: [win64, winarm64] # Choose targets here if you want specific ones
     steps:
       - name: Free Disk-Space
         run: df -h && sudo apt-get clean && docker system prune -a -f && sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc && df -h
@@ -164,7 +164,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        target: [win64] # Choose targets here if you want specific ones
+        target: [win64, winarm64] # Choose targets here if you want specific ones
         variant: [lgpl-shared, lgpl-shared 7.0, lgpl-shared 7.1, gpl, gpl 7.0, gpl 7.1] # Only build this variant
     steps:
       - name: Free Disk-Space
@@ -229,7 +229,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        target: [win64] # Choose targets here if you want specific ones
+        target: [win64, winarm64] # Choose targets here if you want specific ones
         variant: [lgpl-shared, lgpl-shared 7.0, lgpl-shared 7.1, gpl, gpl 7.0, gpl 7.1] # Only build this variant
     steps:
       - name: Free Disk-Space

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -17,11 +17,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        target: [win64,linux64,linuxarm64]
-        variant: [lgpl,gpl 6.1,gpl 5.1,lgpl 6.1,lgpl 5.1,gpl-shared,lgpl-shared,gpl-shared 6.1,gpl-shared 5.1,lgpl-shared 6.1,lgpl-shared 5.1]
+        target: [win64,winarm64,linux64,linuxarm64]
+        variant: [lgpl,gpl 7.1,gpl 7.0,lgpl 7.1,lgpl 7.0,gpl-shared,lgpl-shared,gpl-shared 7.1,gpl-shared 7.0,lgpl-shared 7.1,lgpl-shared 7.0]
         quickbuild: [1]
         include:
           - target: win64
+            variant: gpl
+            quickbuild: ''
+          - target: winarm64
             variant: gpl
             quickbuild: ''
           - target: linux64

--- a/scripts.d/50-libzmq.sh
+++ b/scripts.d/50-libzmq.sh
@@ -4,7 +4,7 @@ SCRIPT_REPO="https://github.com/zeromq/libzmq.git"
 SCRIPT_COMMIT="34f7fa22022bed9e0e390ed3580a1c83ac4a2834"
 
 ffbuild_enabled() {
-    return 0
+    return -1 # unused by Medal
 }
 
 ffbuild_dockerbuild() {


### PR DESCRIPTION
LibZMQ seems to be broken when building for ARM64, so disabled it (we don't seem to use it anyway)